### PR TITLE
Refactor

### DIFF
--- a/src/pages/gymbox/typing-game/typing-game.tsx
+++ b/src/pages/gymbox/typing-game/typing-game.tsx
@@ -153,7 +153,6 @@ function TypingGame() {
   };
 
   React.useEffect(() => {
-    console.log(timerData.playTime);
     if (totalTime <= timerData.playTime) setGamePhase(GamePhase.END);
   }, [timerData.playTime, totalTime]);
 

--- a/src/utils/eventDispatcher.ts
+++ b/src/utils/eventDispatcher.ts
@@ -1,3 +1,5 @@
+import FrameController from "../views/typing/frame-controller";
+
 class Event {
   private name: string;
 
@@ -56,5 +58,45 @@ class EventDispatcher {
     this.events[name].off(cb);
   }
 }
+
+abstract class EventDispatcherWithRAF extends FrameController {
+  events: { [name: string]: Event };
+
+  constructor() {
+    super();
+    this.events = {};
+  }
+
+  emit(name: string, ...args: Array<unknown>) {
+    if (!this.events[name]) {
+      return;
+    }
+
+    this.events[name].callbacks.forEach((cb) => {
+      cb(...args);
+    });
+  }
+
+  addEventListener(name: string, cb: Function): void {
+    if (!this.events[name]) {
+      this.events[name] = new Event(name);
+    }
+
+    this.events[name].on(cb);
+  }
+
+  removeEventListener(name: string, cb?: Function) {
+    if (!cb) {
+      delete this.events[name];
+      return;
+    }
+
+    this.events[name].off(cb);
+  }
+
+  protected abstract play(): void;
+}
+
+export { EventDispatcherWithRAF };
 
 export default EventDispatcher;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,3 @@
 type Coord = { x: number; y: number };
 
-export { Coord };
+export type { Coord };

--- a/src/views/typing/controller.tsx
+++ b/src/views/typing/controller.tsx
@@ -105,7 +105,6 @@ class Controller extends EventDispatcherWithRAF {
         score: this.score,
       })
     );
-    console.log(copiedData);
     this.emitControllerChangeEvent({ data: copiedData });
   }
 

--- a/src/views/typing/frame-controller.ts
+++ b/src/views/typing/frame-controller.ts
@@ -1,0 +1,22 @@
+import { Phase } from "./model";
+
+abstract class FrameController {
+  public isPlaying: Phase = Phase.PAUSED;
+
+  public playTime: number = 0;
+  public timeStamp: number = 0;
+  public rafId: number = 0;
+  public interval: number = 1000 / 60;
+
+  setFps(fps: number) {
+    this.interval = 1000 / fps;
+  }
+
+  getIsPlaying(): Phase {
+    return this.isPlaying;
+  }
+
+  protected abstract play(): void;
+}
+
+export default FrameController;

--- a/src/views/typing/layers/model.ts
+++ b/src/views/typing/layers/model.ts
@@ -1,3 +1,5 @@
+import LevelState from "../level-state";
+
 /**
  * @description for initial data
  */
@@ -15,6 +17,7 @@ interface CanvasLayerConstructor {
 interface DataLayerConstructor extends CanvasLayerConstructor {
   initData?: Words;
   words?: string[];
+  levelState: LevelState;
 }
 
-export { Words, DataProps, CanvasLayerConstructor, DataLayerConstructor };
+export type { Words, DataProps, CanvasLayerConstructor, DataLayerConstructor };

--- a/src/views/typing/layers/render-layer.tsx
+++ b/src/views/typing/layers/render-layer.tsx
@@ -1,20 +1,22 @@
 import BaseLayer from "../../../utils/base-layer";
 import { DataLayerConstructor, DataProps } from "./model";
 import Text, { TextProps, TextState } from "../text/text";
-import { Level } from "../model";
 import { getRandomArbitrary } from "../../../utils/math";
+import LevelState from "../level-state";
 
 class RenderLayer extends BaseLayer {
   private initData: string[] = [];
   private texts: Text[] = [];
   private data: DataProps = { words: [], failed: [] };
 
-  private level: Level = Level.EASY;
+  private levelState: LevelState;
 
   private maxIndex: number = 500; // max index for brute force
 
-  constructor({ canvas, initData }: DataLayerConstructor) {
+  constructor({ canvas, initData, levelState }: DataLayerConstructor) {
     super({ canvas });
+
+    this.levelState = levelState;
 
     if (initData) {
       this.initData = initData;
@@ -28,10 +30,6 @@ class RenderLayer extends BaseLayer {
 
   setTexts(texts: Text[]) {
     this.texts = texts;
-  }
-
-  setLevel(level: Level) {
-    this.level = level;
   }
 
   resetAll(): void {
@@ -72,14 +70,14 @@ class RenderLayer extends BaseLayer {
     let textIndex = 0;
 
     while (textIndex < this.texts.length || textIndex < this.maxIndex) {
-      if (this.level === Level.EASY) {
+      if (this.levelState.getLevel() === this.levelState.Easy) {
         self.setVelocity({ x: 0, y: getRandomArbitrary(0.5, 1) });
-      } else if (this.level === Level.NORMAL) {
+      } else if (this.levelState.getLevel() === this.levelState.Normal) {
         self.setVelocity({
           x: getRandomArbitrary(-0.25, 0.25),
           y: getRandomArbitrary(0.75, 1),
         });
-      } else if (this.level === Level.HARD) {
+      } else if (this.levelState.getLevel() === this.levelState.Hard) {
         self.setVelocity({
           x: getRandomArbitrary(-0.5, 0.5),
           y: getRandomArbitrary(1, 1.25),

--- a/src/views/typing/layers/render-layer.tsx
+++ b/src/views/typing/layers/render-layer.tsx
@@ -190,7 +190,7 @@ class RenderLayer extends BaseLayer {
       if (text.getSpecial() >= 2) ctx.fillStyle = "#C90500";
 
       text.render();
-      text.renderParticles();
+      text.LifeCycleState.getLifeCycle().renderParticles();
     }
 
     ctx.restore();

--- a/src/views/typing/layers/render-layer.tsx
+++ b/src/views/typing/layers/render-layer.tsx
@@ -11,7 +11,7 @@ class RenderLayer extends BaseLayer {
 
   private levelState: LevelState;
 
-  private maxIndex: number = 500; // max index for brute force
+  private maxIndex: number = 200; // max index for brute force
 
   constructor({ canvas, initData, levelState }: DataLayerConstructor) {
     super({ canvas });
@@ -70,19 +70,10 @@ class RenderLayer extends BaseLayer {
     let textIndex = 0;
 
     while (textIndex < this.texts.length || textIndex < this.maxIndex) {
-      if (this.levelState.getLevel() === this.levelState.Easy) {
-        self.setVelocity({ x: 0, y: getRandomArbitrary(0.5, 1) });
-      } else if (this.levelState.getLevel() === this.levelState.Normal) {
-        self.setVelocity({
-          x: getRandomArbitrary(-0.25, 0.25),
-          y: getRandomArbitrary(0.75, 1),
-        });
-      } else if (this.levelState.getLevel() === this.levelState.Hard) {
-        self.setVelocity({
-          x: getRandomArbitrary(-0.5, 0.5),
-          y: getRandomArbitrary(1, 1.25),
-        });
-      }
+      self.setVelocity({
+        x: this.levelState.getLevel().getRandomXvelocity(),
+        y: this.levelState.getLevel().getRandomYvelocity(),
+      });
 
       let overLapped = false;
       this.texts.forEach((text) => {

--- a/src/views/typing/level-state.ts
+++ b/src/views/typing/level-state.ts
@@ -1,0 +1,95 @@
+interface Level {
+  LevelState: LevelState;
+  value: number;
+
+  increase: VoidFunction;
+  decrease: VoidFunction;
+}
+
+/** @url https://www.youtube.com/watch?v=gMyRtqwxr10 */
+class LevelState {
+  public Easy: Level;
+  public Normal: Level;
+  public Hard: Level;
+
+  public currentLevel: Level;
+
+  constructor() {
+    this.Easy = new Easy(this);
+    this.Normal = new Normal(this);
+    this.Hard = new Hard(this);
+
+    this.currentLevel = this.Easy;
+    this.setLevel(this.Easy);
+  }
+
+  public setLevel(level: Level) {
+    this.currentLevel = level;
+  }
+
+  public getLevel(): Level {
+    return this.currentLevel;
+  }
+
+  public getLevelName(): string {
+    return this.currentLevel.constructor.name;
+  }
+}
+
+class Easy implements Level {
+  public LevelState: LevelState;
+  readonly value: number = 0;
+
+  constructor(LevelState: LevelState) {
+    this.LevelState = LevelState;
+  }
+
+  public increase() {
+    this.LevelState.setLevel(this.LevelState.Normal);
+  }
+  public decrease() {
+    throw new Error(`${this.LevelState.getLevelName()} is minimum level`);
+  }
+}
+
+class Normal implements Level {
+  public LevelState: LevelState;
+  readonly value: number = 1;
+
+  constructor(LevelState: LevelState) {
+    this.LevelState = LevelState;
+  }
+
+  public increase() {
+    this.LevelState.setLevel(this.LevelState.Hard);
+  }
+  public decrease() {
+    this.LevelState.setLevel(this.LevelState.Easy);
+  }
+}
+
+class Hard implements Level {
+  public LevelState: LevelState;
+  readonly value: number = 2;
+
+  constructor(LevelState: LevelState) {
+    this.LevelState = LevelState;
+  }
+
+  public increase() {
+    throw new Error(`${this.LevelState.getLevelName()} is maximum level`);
+  }
+  public decrease() {
+    this.LevelState.setLevel(this.LevelState.Normal);
+  }
+}
+
+const con = new LevelState();
+con.getLevel().increase();
+con.setLevel(new Hard(con));
+
+console.log(`Level : ${con.getLevelName()}`);
+
+export type { Level };
+
+export default LevelState;

--- a/src/views/typing/level-state.ts
+++ b/src/views/typing/level-state.ts
@@ -84,12 +84,6 @@ class Hard implements Level {
   }
 }
 
-const con = new LevelState();
-con.getLevel().increase();
-con.setLevel(new Hard(con));
-
-console.log(`Level : ${con.getLevelName()}`);
-
 export type { Level };
 
 export default LevelState;

--- a/src/views/typing/level-state.ts
+++ b/src/views/typing/level-state.ts
@@ -1,7 +1,11 @@
+import { getRandomArbitrary } from "../../utils/math";
+
 interface Level {
   LevelState: LevelState;
   value: number;
 
+  getRandomXvelocity: () => number;
+  getRandomYvelocity: () => number;
   increase: VoidFunction;
   decrease: VoidFunction;
 }
@@ -44,6 +48,14 @@ class Easy implements Level {
     this.LevelState = LevelState;
   }
 
+  public getRandomXvelocity() {
+    return 0;
+  }
+
+  public getRandomYvelocity() {
+    return getRandomArbitrary(0.5, 1);
+  }
+
   public increase() {
     this.LevelState.setLevel(this.LevelState.Normal);
   }
@@ -60,6 +72,14 @@ class Normal implements Level {
     this.LevelState = LevelState;
   }
 
+  public getRandomXvelocity() {
+    return getRandomArbitrary(-0.25, 0.25);
+  }
+
+  public getRandomYvelocity() {
+    return getRandomArbitrary(0.75, 1);
+  }
+
   public increase() {
     this.LevelState.setLevel(this.LevelState.Hard);
   }
@@ -74,6 +94,14 @@ class Hard implements Level {
 
   constructor(LevelState: LevelState) {
     this.LevelState = LevelState;
+  }
+
+  public getRandomXvelocity() {
+    return getRandomArbitrary(-0.5, 0.5);
+  }
+
+  public getRandomYvelocity() {
+    return getRandomArbitrary(1, 1.25);
   }
 
   public increase() {

--- a/src/views/typing/model.ts
+++ b/src/views/typing/model.ts
@@ -66,7 +66,7 @@ type TimerProps = {
 type TimerChangeParams = { data: TimerProps };
 type TimerChangeHandler = (params: TimerChangeParams) => void;
 
-export {
+export type {
   CanvasDataChangeParams,
   CanvasDataChangeHandler,
   ControllerProps,
@@ -77,6 +77,6 @@ export {
   TimerChangeHandler,
   TypingProps,
   TypingRef,
-  Phase,
-  Level,
 };
+
+export { Phase, Level };

--- a/src/views/typing/text/rigid-body.ts
+++ b/src/views/typing/text/rigid-body.ts
@@ -1,0 +1,78 @@
+import { Coord } from "../../../utils/types";
+
+abstract class RigidBody {
+  public position: Coord = { x: 0, y: 0 };
+  public velocity: Coord = { x: 0, y: 0 };
+  public collideVelocity: Coord = { x: 0, y: 0 };
+  public dimension: { width: number; height: number } = {
+    width: 0,
+    height: 0,
+  };
+  public mass: number = 1;
+  public corFactor: number = 1.2;
+
+  /**
+   * @url http://programmerart.weebly.com/separating-axis-theorem.html
+   * @url https://blog.naver.com/PostView.naver?blogId=skz1024&logNo=222758566138
+   * @url https://github.com/DongChyeon/JS-Toy-Projects/blob/master/AirHockey/game.js#L22C28-L22C28
+   * @url https://velog.io/@dongchyeon/%EC%9E%90%EB%B0%94%EC%8A%A4%ED%81%AC%EB%A6%BD%ED%8A%B8%EB%A1%9C-%EC%97%90%EC%96%B4-%ED%95%98%ED%82%A4-%EA%B2%8C%EC%9E%84%EC%9D%84-%EB%A7%8C%EB%93%A4%EC%96%B4%EB%B3%B4%EC%9E%90
+   */
+  getVelocityAfterCollision(collidedText: RigidBody): Coord {
+    const velocity = {
+      x:
+        ((this.mass - collidedText.mass * this.corFactor) /
+          (this.mass + collidedText.mass)) *
+          this.velocity.x +
+        ((collidedText.mass + collidedText.mass * this.corFactor) /
+          (this.mass + collidedText.mass)) *
+          collidedText.velocity.x,
+      y:
+        ((this.mass - collidedText.mass * this.corFactor) /
+          (this.mass + collidedText.mass)) *
+          this.velocity.y +
+        ((collidedText.mass + collidedText.mass * this.corFactor) /
+          (this.mass + collidedText.mass)) *
+          collidedText.velocity.y,
+    };
+    return velocity;
+  }
+
+  getIsCollided(collidedText: RigidBody): boolean {
+    return (
+      this.position.x + this.dimension.width >= collidedText.position.x &&
+      this.position.x <=
+        collidedText.position.x + collidedText.dimension.width &&
+      this.position.y + this.dimension.height >= collidedText.position.y &&
+      this.position.y <= collidedText.position.y + collidedText.dimension.height
+    );
+  }
+
+  getPosition(): Coord {
+    return this.position;
+  }
+
+  getDimension(): { width: number; height: number } {
+    return this.dimension;
+  }
+
+  getVelocity(): Coord {
+    return this.velocity;
+  }
+
+  setPosition(position: Coord) {
+    this.position = position;
+  }
+
+  setVelocity(velocity: Coord) {
+    this.velocity = velocity;
+  }
+
+  setCollideVelocity(velocity: Coord) {
+    this.collideVelocity = velocity;
+  }
+
+  protected abstract update(): void;
+  protected abstract render(): void;
+}
+
+export default RigidBody;

--- a/src/views/typing/text/scorable.ts
+++ b/src/views/typing/text/scorable.ts
@@ -1,0 +1,37 @@
+import { divideKOR, isKOR } from "../../../utils/parse-korean";
+import Text from "./text";
+
+interface Scorable {
+  subject: Text;
+
+  score: number;
+  specialty: number;
+}
+
+class ScorableSubject implements Scorable {
+  public subject: Text;
+  public score: number = 0;
+  public specialty: number = 1;
+
+  constructor(text: Text, specialty: number) {
+    this.subject = text;
+    this.specialty = specialty;
+
+    if (isKOR(this.subject.data)) {
+      const splitedKOR = divideKOR(this.subject.data);
+      this.score = splitedKOR.length * this.specialty;
+    } else {
+      this.score = this.subject.data.length * this.specialty;
+    }
+  }
+
+  public getSpecialty() {
+    return this.specialty;
+  }
+
+  public getScore() {
+    return this.score;
+  }
+}
+
+export default ScorableSubject;

--- a/src/views/typing/text/text-state.ts
+++ b/src/views/typing/text/text-state.ts
@@ -1,0 +1,114 @@
+import Text from "./text";
+
+interface LifeCycle {
+  LifeCycleState: LifeCycleState;
+  Text: Text;
+
+  toNextStep: VoidFunction;
+  update: VoidFunction;
+}
+
+class LifeCycleState {
+  public Init: LifeCycle;
+  public Particled: LifeCycle;
+  public Dead: LifeCycle;
+
+  public currentCycle: LifeCycle;
+
+  constructor({ Text }: { Text: Text }) {
+    this.Init = new Init(this, Text);
+    this.Particled = new Particled(this, Text);
+    this.Dead = new Dead(this, Text);
+
+    this.currentCycle = this.Init;
+  }
+
+  public setLifeCycle(LifeCycle: LifeCycle) {
+    this.currentCycle = LifeCycle;
+  }
+
+  public getLifeCycle(): LifeCycle {
+    return this.currentCycle;
+  }
+
+  public getLifeCycleName(): string {
+    return this.currentCycle.constructor.name;
+  }
+}
+
+class Init implements LifeCycle {
+  public LifeCycleState: LifeCycleState;
+  public Text: Text;
+
+  constructor(LifeCycleState: LifeCycleState, Text: Text) {
+    this.LifeCycleState = LifeCycleState;
+    this.Text = Text;
+  }
+
+  toNextStep() {
+    this.LifeCycleState.setLifeCycle(this.LifeCycleState.Particled);
+  }
+
+  update() {
+    const text = this.Text;
+    text.position.x += text.velocity.x + text.collideVelocity.x;
+    text.position.y += text.velocity.y + text.collideVelocity.y;
+
+    if (text.collideVelocity.x > 0.1) text.collideVelocity.x *= 0.6;
+    if (text.collideVelocity.y > 0.1) text.collideVelocity.y *= 0.6;
+  }
+}
+
+class Particled implements LifeCycle {
+  public LifeCycleState: LifeCycleState;
+  public Text: Text;
+
+  constructor(LifeCycleState: LifeCycleState, Text: Text) {
+    this.LifeCycleState = LifeCycleState;
+    this.Text = Text;
+  }
+
+  toNextStep() {
+    this.LifeCycleState.setLifeCycle(this.LifeCycleState.Dead);
+  }
+
+  update() {
+    this.Text.splitToParticle();
+    this.toNextStep();
+  }
+}
+
+class Dead implements LifeCycle {
+  public LifeCycleState: LifeCycleState;
+  public Text: Text;
+
+  constructor(LifeCycleState: LifeCycleState, Text: Text) {
+    this.LifeCycleState = LifeCycleState;
+    this.Text = Text;
+  }
+
+  toNextStep() {
+    throw new Error("Already Dead");
+  }
+
+  update() {
+    const text = this.Text;
+    if (text.particles.length <= 0) return;
+    text.particles.forEach((particle) => {
+      const { x: posX, y: posY } = particle.getPosition();
+      const { x: veloX, y: veloY } = particle.getVelocity();
+      particle.setPosition({
+        x: posX + veloX,
+        y: posY + veloY,
+      });
+    });
+    if (text.particleLifeTime <= 0) {
+      text.particles = [];
+      text.particleLifeTime = 0;
+    }
+  }
+}
+
+export type { LifeCycle };
+
+export default LifeCycleState;

--- a/src/views/typing/text/text-state.ts
+++ b/src/views/typing/text/text-state.ts
@@ -1,3 +1,4 @@
+import { getRandomArbitrary } from "../../../utils/math";
 import Text from "./text";
 
 interface LifeCycle {
@@ -6,6 +7,7 @@ interface LifeCycle {
 
   toNextStep: VoidFunction;
   update: VoidFunction;
+  renderParticles: VoidFunction;
 }
 
 class LifeCycleState {
@@ -49,7 +51,9 @@ class Init implements LifeCycle {
     this.LifeCycleState.setLifeCycle(this.LifeCycleState.Particled);
   }
 
-  update() {
+  public renderParticles() {}
+
+  public update() {
     const text = this.Text;
     text.position.x += text.velocity.x + text.collideVelocity.x;
     text.position.y += text.velocity.y + text.collideVelocity.y;
@@ -72,8 +76,40 @@ class Particled implements LifeCycle {
     this.LifeCycleState.setLifeCycle(this.LifeCycleState.Dead);
   }
 
-  update() {
-    this.Text.splitToParticle();
+  splitToParticle() {
+    if (this.LifeCycleState.getLifeCycle() !== this.LifeCycleState.Particled)
+      return;
+
+    const text = this.Text;
+
+    text.data.split("").forEach((d, i) => {
+      text.particles.push(
+        new Text({
+          data: d,
+          ctx: text.ctx,
+        })
+      );
+      text.particles[i].setVelocity(text.velocity);
+    });
+
+    text.particles.forEach((particle, index) => {
+      const { width } = particle.getDimension();
+      const { x: veloX, y: veloY } = particle.velocity;
+      particle.setPosition({
+        x: text.position.x + (index + 1) * width,
+        y: text.position.y,
+      });
+      particle.setVelocity({
+        x: getRandomArbitrary(-veloX * 2 || -2, veloX * 2 || 2),
+        y: getRandomArbitrary(veloY * 1, veloY * 2),
+      });
+    });
+  }
+
+  public renderParticles() {}
+
+  public update() {
+    this.splitToParticle();
     this.toNextStep();
   }
 }
@@ -91,7 +127,28 @@ class Dead implements LifeCycle {
     throw new Error("Already Dead");
   }
 
-  update() {
+  public renderParticles() {
+    const text = this.Text;
+    if (text.particles.length <= 0 || text.particleLifeTime <= 0) return;
+    text.particles.forEach((particle, index) => {
+      text.ctx.save();
+      text.ctx.textAlign = "left";
+      text.ctx.textBaseline = "top";
+      text.ctx.globalAlpha = text.particleLifeTime / 100;
+
+      const { x, y } = particle.getPosition();
+      const { width, height } = particle.getDimension();
+      text.ctx.translate(x + width / 2, y + height / 2);
+      text.ctx.rotate(Math.PI / -(text.particleLifeTime / (index * 10)));
+      text.ctx.fillText(particle.textData(), -width / 2, -height / 2);
+      text.ctx.translate(-(x + width / 2), -(y + height / 2));
+
+      text.ctx.restore();
+    });
+    text.particleLifeTime -= 1;
+  }
+
+  public update() {
     const text = this.Text;
     if (text.particles.length <= 0) return;
     text.particles.forEach((particle) => {

--- a/src/views/typing/text/text.ts
+++ b/src/views/typing/text/text.ts
@@ -1,6 +1,7 @@
 import { divideKOR, isKOR } from "../../../utils/parse-korean";
 import { Coord } from "../../../utils/types";
 import RigidBody from "./rigid-body";
+import ScorableSubject from "./scorable";
 import LifeCycleState from "./text-state";
 
 export interface TextProps {
@@ -23,8 +24,9 @@ class Text extends RigidBody {
   public ctx: CanvasRenderingContext2D;
 
   public data: string = "";
-  private score: number = 0;
   private special: number = 1;
+
+  public scorableSubject: ScorableSubject;
 
   public particles: Text[] = [];
   public particleLifeTime: number = 100;
@@ -36,6 +38,8 @@ class Text extends RigidBody {
 
     this.ctx = ctx;
     this.data = data;
+
+    this.scorableSubject = new ScorableSubject(this, this.special);
 
     this.LifeCycleState = new LifeCycleState({ Text: this });
 
@@ -49,21 +53,14 @@ class Text extends RigidBody {
       (getTextMetrics(ctx, data).actualBoundingBoxAscent +
         getTextMetrics(ctx, data).actualBoundingBoxDescent) *
       1;
-
-    if (isKOR(data)) {
-      const splitedKOR = divideKOR(data);
-      this.score = splitedKOR.length * this.special;
-    } else {
-      this.score = data.length * this.special;
-    }
   }
 
   getSpecial(): number {
-    return this.special;
+    return this.scorableSubject.getSpecialty();
   }
 
   getScore(): number {
-    return this.score;
+    return this.scorableSubject.getScore();
   }
 
   textData(): string {

--- a/src/views/typing/text/text.ts
+++ b/src/views/typing/text/text.ts
@@ -1,6 +1,7 @@
 import { getRandomArbitrary } from "../../../utils/math";
 import { divideKOR, isKOR } from "../../../utils/parse-korean";
 import { Coord } from "../../../utils/types";
+import RigidBody from "./rigid-body";
 
 export interface TextProps {
   data: string;
@@ -18,7 +19,7 @@ export enum TextState {
   DEAD = "dead",
 }
 
-class Text {
+class Text extends RigidBody {
   protected ctx: CanvasRenderingContext2D;
 
   private data: string = "";
@@ -26,20 +27,12 @@ class Text {
   private state: TextState = TextState.INIT;
   private special: number = 1;
 
-  private position: Coord = { x: 0, y: 0 };
-  private velocity: Coord = { x: 0, y: 0 };
-  private collideVelocity: Coord = { x: 0, y: 0 };
-  private dimension: { width: number; height: number } = {
-    width: 0,
-    height: 0,
-  };
-  private mass: number = 1;
-  private corFactor: number = 1.2;
-
   private particles: Text[] = [];
   private particleLifeTime: number = 100;
 
   constructor({ data, ctx, position, mass, velocity, special }: TextProps) {
+    super();
+
     this.ctx = ctx;
 
     this.data = data;
@@ -76,68 +69,8 @@ class Text {
     return this.score;
   }
 
-  getPosition(): Coord {
-    return this.position;
-  }
-
-  getDimension(): { width: number; height: number } {
-    return this.dimension;
-  }
-
-  getVelocity(): Coord {
-    return this.velocity;
-  }
-
-  getVelocityAfterCollision(collidedText: Text): Coord {
-    /**
-     * @url http://programmerart.weebly.com/separating-axis-theorem.html
-     * @url https://blog.naver.com/PostView.naver?blogId=skz1024&logNo=222758566138
-     * @url https://github.com/DongChyeon/JS-Toy-Projects/blob/master/AirHockey/game.js#L22C28-L22C28
-     * @url https://velog.io/@dongchyeon/%EC%9E%90%EB%B0%94%EC%8A%A4%ED%81%AC%EB%A6%BD%ED%8A%B8%EB%A1%9C-%EC%97%90%EC%96%B4-%ED%95%98%ED%82%A4-%EA%B2%8C%EC%9E%84%EC%9D%84-%EB%A7%8C%EB%93%A4%EC%96%B4%EB%B3%B4%EC%9E%90
-     */
-    const velocity = {
-      x:
-        ((this.mass - collidedText.mass * this.corFactor) /
-          (this.mass + collidedText.mass)) *
-          this.velocity.x +
-        ((collidedText.mass + collidedText.mass * this.corFactor) /
-          (this.mass + collidedText.mass)) *
-          collidedText.velocity.x,
-      y:
-        ((this.mass - collidedText.mass * this.corFactor) /
-          (this.mass + collidedText.mass)) *
-          this.velocity.y +
-        ((collidedText.mass + collidedText.mass * this.corFactor) /
-          (this.mass + collidedText.mass)) *
-          collidedText.velocity.y,
-    };
-    return velocity;
-  }
-
-  getIsCollided(collidedText: Text): boolean {
-    return (
-      this.position.x + this.dimension.width >= collidedText.position.x &&
-      this.position.x <=
-        collidedText.position.x + collidedText.dimension.width &&
-      this.position.y + this.dimension.height >= collidedText.position.y &&
-      this.position.y <= collidedText.position.y + collidedText.dimension.height
-    );
-  }
-
   textData(): string {
     return this.data;
-  }
-
-  setPosition(position: Coord) {
-    this.position = position;
-  }
-
-  setVelocity(velocity: Coord) {
-    this.velocity = velocity;
-  }
-
-  setCollideVelocity(velocity: Coord) {
-    this.collideVelocity = velocity;
   }
 
   setIsAlive(state: TextState) {

--- a/src/views/typing/text/text.ts
+++ b/src/views/typing/text/text.ts
@@ -2,6 +2,7 @@ import { getRandomArbitrary } from "../../../utils/math";
 import { divideKOR, isKOR } from "../../../utils/parse-korean";
 import { Coord } from "../../../utils/types";
 import RigidBody from "./rigid-body";
+import LifeCycleState, { LifeCycle } from "./text-state";
 
 export interface TextProps {
   data: string;
@@ -27,20 +28,18 @@ class Text extends RigidBody {
   private state: TextState = TextState.INIT;
   private special: number = 1;
 
-  private particles: Text[] = [];
-  private particleLifeTime: number = 100;
+  public particles: Text[] = [];
+  public particleLifeTime: number = 100;
 
-  constructor({ data, ctx, position, mass, velocity, special }: TextProps) {
+  public LifeCycle: LifeCycleState;
+
+  constructor({ data, ctx }: TextProps) {
     super();
 
     this.ctx = ctx;
-
     this.data = data;
 
-    this.position = position ?? { x: 0, y: 0 };
-    this.velocity = velocity ?? { x: 0, y: 0 };
-    this.mass = mass ?? 1;
-    this.special = special ?? 1;
+    this.LifeCycle = new LifeCycleState({ Text: this });
 
     const getTextMetrics = (
       ctx: CanvasRenderingContext2D,

--- a/src/views/typing/typing.tsx
+++ b/src/views/typing/typing.tsx
@@ -52,7 +52,7 @@ const Typing = forwardRef<TypingRef, TypingProps>(function Typing(
       renderLayer: renderCanvasRef,
       initData: props.initData,
     });
-    editor.setFps(props.fps || 60);
+    editor.setFps(props.fps ?? 60);
     editor.setIsPlaying(Phase.PAUSED);
     setEditor(editor);
 


### PR DESCRIPTION
## TODOs
1. extract data logic from render layer

logics that control the data of the whole game is implemented in the render-layer, this is a nonsense. Maybe a datasource observer held by the controller pacade can handle this. It can be just a subclass but logics for data will affect the whole game(e.g. maybe background or any other input sources) I'll give it try to implement with observer pattern

2. find a better implementation for EventDispatcherWithRAF(aka. frameController)

https://github.com/Lee-Si-Yoon/rc-minigames/blob/aca2bedc56f158001088cb8e423effe433cbacd5/src/views/typing/frame-controller.ts#L3-L20

currently this class is just extending & extending, I couldn't find a better way for now since play function is depending on the controllers internal method 

3. find a better implementation for setters

https://github.com/Lee-Si-Yoon/rc-minigames/blob/aca2bedc56f158001088cb8e423effe433cbacd5/src/views/typing/controller.tsx#L138-L148

levelState itself represents the level player is playing now and enum Level also does that too. This duplicated definition occurred because I wanted to make things easy to on the page level implementation like below

https://github.com/Lee-Si-Yoon/rc-minigames/blob/aca2bedc56f158001088cb8e423effe433cbacd5/src/pages/gymbox/typing-game/typing-game.tsx#L184-L190

I'm currently stuck with how to configure adapter to this

4. Q. IMO level-state is over-engineering 

https://github.com/Lee-Si-Yoon/rc-minigames/blob/aca2bedc56f158001088cb8e423effe433cbacd5/src/views/typing/level-state.ts#L3-L11

I'm curious if this class is helpful. Level transition limiter & getting a threshold for velocity per level is only what it does.